### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and define authority in strings.xml like this
 	<string name="multiprocess_preferences_authority" translatable="false">com.gdubina.multiprocesspreferences.PREFFERENCE_AUTHORITY</string>
 
 
-##Example
+## Example
 
 *Default sharedprefferences*  
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
